### PR TITLE
Add services to pause/resume execution

### DIFF
--- a/behaviortree_ros2/CMakeLists.txt
+++ b/behaviortree_ros2/CMakeLists.txt
@@ -11,6 +11,7 @@ set(THIS_PACKAGE_DEPS
     behaviortree_cpp
     btcpp_ros2_interfaces
     generate_parameter_library
+    std_srvs
     )
 
 find_package(ament_cmake REQUIRED)

--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -21,6 +21,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
+#include "std_srvs/srv/trigger.hpp"
+
 namespace BT
 {
 
@@ -35,6 +37,7 @@ class TreeExecutionServer
 public:
   using ExecuteTree = btcpp_ros2_interfaces::action::ExecuteTree;
   using GoalHandleExecuteTree = rclcpp_action::ServerGoalHandle<ExecuteTree>;
+  using Trigger = std_srvs::srv::Trigger;
 
   /**
    * @brief Constructor that will create its own instance of rclcpp::Node
@@ -187,6 +190,22 @@ private:
    * @param goal_handle Server goal handle to process feedback and set the response when finished
    */
   void execute(const std::shared_ptr<GoalHandleExecuteTree> goal_handle);
+
+  /**
+   * @brief Handle the pause service request
+   * @param request The request to pause the action server
+   * @param response The response to the pause request
+   */
+  void handle_pause(Trigger::Request::ConstSharedPtr request,
+                    Trigger::Response::SharedPtr response);
+
+  /**
+   * @brief Handle the resume service request
+   * @param request The request to resume the action server
+   * @param response The response to the resume request
+   */
+  void handle_resume(Trigger::Request::ConstSharedPtr request,
+                     Trigger::Response::SharedPtr response);
 };
 
 }  // namespace BT

--- a/behaviortree_ros2/package.xml
+++ b/behaviortree_ros2/package.xml
@@ -2,7 +2,7 @@
   <name>behaviortree_ros2</name>
   <version>0.2.0</version>
   <description>
-  This package provides a ROS2 wrapper, on top of BehaviorTree.CPP.
+    This package provides a ROS2 wrapper, on top of BehaviorTree.CPP.
   </description>
 
   <maintainer email="davide.faconti@gmail.com">Davide Faconti</maintainer>
@@ -19,9 +19,10 @@
   <depend>behaviortree_cpp</depend>
   <depend>generate_parameter_library</depend>
   <depend>btcpp_ros2_interfaces</depend>
+  <depend>std_srvs</depend>
 
-<export>
-  <build_type>ament_cmake</build_type>
-</export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -40,6 +40,10 @@ struct TreeExecutionServer::Pimpl
   rclcpp_action::Server<ExecuteTree>::SharedPtr action_server;
   std::thread action_thread;
 
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr pause_service;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resume_service;
+  bool paused = false;
+
   std::shared_ptr<bt_server::ParamListener> param_listener;
   bt_server::Params params;
 
@@ -76,6 +80,16 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::Node::SharedPtr& node)
       },
       [this](const std::shared_ptr<GoalHandleExecuteTree> goal_handle) {
         handle_accepted(std::move(goal_handle));
+      });
+
+  p_->pause_service = node_->create_service<Trigger>(
+      "pause_tree_execution",
+      [this](Trigger::Request::ConstSharedPtr request,
+             Trigger::Response::SharedPtr response) { handle_pause(request, response); });
+  p_->resume_service = node_->create_service<Trigger>(
+      "resume_tree_execution", [this](Trigger::Request::ConstSharedPtr request,
+                                      Trigger::Response::SharedPtr response) {
+        handle_resume(request, response);
       });
 
   // we use a wall timer to run asynchronously executeRegistration();
@@ -157,6 +171,7 @@ void TreeExecutionServer::handle_accepted(
   {
     p_->action_thread.join();
   }
+  p_->paused = false;
   // To avoid blocking the executor start a new thread to process the goal
   p_->action_thread = std::thread{ [=]() { execute(goal_handle); } };
 }
@@ -222,8 +237,16 @@ void TreeExecutionServer::execute(
         return;
       }
 
-      // tick the tree once and publish the action feedback
-      status = p_->tree.tickExactlyOnce();
+      // tick the tree once (if not paused) and publish the action feedback
+      if(p_->paused)
+      {
+        status = BT::NodeStatus::RUNNING;
+        RCLCPP_DEBUG(kLogger, "Action Server is paused, skipping tick.");
+      }
+      else
+      {
+        status = p_->tree.tickExactlyOnce();
+      }
 
       if(const auto res = onLoopAfterTick(status); res.has_value())
       {
@@ -232,7 +255,13 @@ void TreeExecutionServer::execute(
         return;
       }
 
-      if(const auto res = onLoopFeedback(); res.has_value())
+      if(p_->paused)
+      {
+        auto feedback = std::make_shared<ExecuteTree::Feedback>();
+        feedback->message = "Tree execution paused.";
+        goal_handle->publish_feedback(feedback);
+      }
+      else if(const auto res = onLoopFeedback(); res.has_value())
       {
         auto feedback = std::make_shared<ExecuteTree::Feedback>();
         feedback->message = res.value();
@@ -282,6 +311,20 @@ void TreeExecutionServer::execute(
     RCLCPP_ERROR(kLogger, action_result->return_message.c_str());
     goal_handle->abort(action_result);
   }
+}
+
+void TreeExecutionServer::handle_pause(Trigger::Request::ConstSharedPtr /*request*/,
+                                       Trigger::Response::SharedPtr response)
+{
+  p_->paused = true;
+  response->success = true;
+}
+
+void TreeExecutionServer::handle_resume(Trigger::Request::ConstSharedPtr /*request*/,
+                                        Trigger::Response::SharedPtr response)
+{
+  p_->paused = false;
+  response->success = true;
 }
 
 const std::string& TreeExecutionServer::treeName() const


### PR DESCRIPTION
# Overview
<!-- Briefly describe the purpose of this PR. Aim for 2–3 sentences. -->
Adds services to pause/resume BT execution.
When paused, it does almost everything the same, just skips the BT "tick". Meaning, the ROS Action keeps running and Action feedback keeps getting published. The feedback-string will indicate that the execution is paused.

# Type(s) of Change
- 🚀 Feature
<!-- - 🐞 Bugfix -->
<!-- - ♻️ Refactor / Code Cleanup -->
<!-- - 📈 Tech Debt Reduction -->
<!-- - 📄 Documentation -->
<!-- - ⚙️ Infrastructure / Build System -->

# Description of Changes
- Added Services to pause/resume execution
- Add handling of the paused state
- Modified the Action feedback message while paused

# Testing
- Tested using CLI and UI on a Panther

# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No

## LADR Documentation
<!-- Nexxis LADR repo (private): https://github.com/Nexxis-Technology/LADR -->
**Does this change require a LADR?** No

# Additional Context (Optional)
Any ROS2 Action that was started from within the BT (or any goal position sent to firmware, PID controller, etc) will of course run until completion as it's not dependent on the BT ticking.

# PR Checklist

## Developer Submission Checklist
<!-- Please check off items you've completed before submitting. -->
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [ ] Code has been reviewed and all comments have been addressed *
- [ ] Testing documentation has been reviewed (or confirmed not needed)
- [ ] LADR documentation has been reviewed (or confirmed not needed)
- [ ] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



