### PR TITLE
NST-1563 Recursive File Search

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <thread>
+#include <filesystem>
 
 #include "btcpp_ros2_interfaces/msg/node_status.hpp"
 
@@ -43,7 +44,7 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
  * @param parameter_value String containing 'package_name/subfolder' for the directory path to look up
  * @return Full path to the directory specified by the parameter_value
  */
-std::string GetDirectoryPath(const std::string& parameter_value);
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value);
 
 /**
  * @brief Function to load BehaviorTree xml files from a specific directory
@@ -52,7 +53,7 @@ std::string GetDirectoryPath(const std::string& parameter_value);
  * @param directory_path Full path to the directory to search for BehaviorTree definitions
  */
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path);
+                       const std::filesystem::path& directory_path);
 
 /**
  * @brief Function to load a BehaviorTree ROS plugin (or standard BT.CPP plugins)

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -93,6 +93,12 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
       std::filesystem::directory_options::follow_directory_symlink;
   for(const auto& entry : recursive_directory_iterator(directory_path, directory_options))
   {
+    if(entry.is_symlink() && !entry.exists())
+    {
+      RCLCPP_DEBUG(kLogger, "Skipping broken symlink: %s", entry.path().c_str());
+      continue;
+    }
+
     if(entry.path().extension() == ".xml")
     {
       try

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -89,7 +89,9 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
   using std::filesystem::recursive_directory_iterator;
-  for(const auto& entry : recursive_directory_iterator(directory_path))
+  const auto directory_options =
+      std::filesystem::directory_options::follow_directory_symlink;
+  for(const auto& entry : recursive_directory_iterator(directory_path, directory_options))
   {
     if(entry.path().extension() == ".xml")
     {

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -22,6 +22,12 @@ static const auto kLogger = rclcpp::get_logger("bt_action_server");
 namespace BT
 {
 
+std::filesystem::path path_from_iterators(const std::filesystem::path::iterator& first,
+                                          const std::filesystem::path::iterator& last)
+{
+  return std::accumulate(first, last, std::filesystem::path{}, std::divides{});
+}
+
 btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
 {
   btcpp_ros2_interfaces::msg::NodeStatus action_status;
@@ -47,23 +53,26 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
   return action_status;
 }
 
-std::string GetDirectoryPath(const std::string& parameter_value)
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
 {
-  std::string package_name, subfolder;
-  auto pos = parameter_value.find_first_of("/");
-  if(pos == parameter_value.size())
+  const std::filesystem::path search_path(parameter_value);
+  const auto num_path_components = std::distance(search_path.begin(), search_path.end());
+
+  if(num_path_components < 2)
   {
     RCLCPP_ERROR(kLogger, "Invalid Parameter: %s. Missing subfolder delimiter '/'.",
                  parameter_value.c_str());
     return "";
   }
 
-  package_name = std::string(parameter_value.begin(), parameter_value.begin() + pos);
-  subfolder = std::string(parameter_value.begin() + pos + 1, parameter_value.end());
+  const auto package_name = *search_path.begin();
+  const auto subfolder = path_from_iterators(++search_path.begin(), search_path.end());
+
   try
   {
-    std::string search_directory =
-        ament_index_cpp::get_package_share_directory(package_name) + "/" + subfolder;
+    const auto package_share_dir =
+        std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
+    const auto search_directory = package_share_dir / subfolder;
     RCLCPP_DEBUG(kLogger, "Searching for Plugins/BehaviorTrees in path: %s",
                  search_directory.c_str());
     return search_directory;
@@ -73,11 +82,11 @@ std::string GetDirectoryPath(const std::string& parameter_value)
     RCLCPP_ERROR(kLogger, "Failed to find package: %s \n %s", package_name.c_str(),
                  e.what());
   }
-  return "";
+  return {};
 }
 
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path)
+                       const std::filesystem::path& directory_path)
 {
   using std::filesystem::directory_iterator;
   for(const auto& entry : directory_iterator(directory_path))
@@ -147,8 +156,8 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
-    using std::filesystem::directory_iterator;
 
+    using std::filesystem::directory_iterator;
     for(const auto& entry : directory_iterator(plugin_directory))
     {
       if(entry.path().extension() == ".so")

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -88,8 +88,8 @@ std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
-  using std::filesystem::directory_iterator;
-  for(const auto& entry : directory_iterator(directory_path))
+  using std::filesystem::recursive_directory_iterator;
+  for(const auto& entry : recursive_directory_iterator(directory_path))
   {
     if(entry.path().extension() == ".xml")
     {
@@ -157,8 +157,8 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
       continue;
     }
 
-    using std::filesystem::directory_iterator;
-    for(const auto& entry : directory_iterator(plugin_directory))
+    using std::filesystem::recursive_directory_iterator;
+    for(const auto& entry : recursive_directory_iterator(plugin_directory))
     {
       if(entry.path().extension() == ".so")
       {


### PR DESCRIPTION
# Overview
Look recursively for XML files in the paths given as parameter, instead of only in explicitly listed directories.

# Changes
- Refactored functions to use `std::filesystem::path` instead of `std::string` because
  - It is the right thing to use when handling paths
  - It fixed an error in the check, whether the given path contained a delimiter (checking for a delimiter could already be seen as faulty as the intention was to check whether there's at least 2 path components - package name and relative path from there)
- Use recursive directory iterator and have it follow symlinks