### PR TITLE
NST-1640 BT from other sources than ROS packages

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <thread>
+#include <filesystem>
 
 #include "btcpp_ros2_interfaces/msg/node_status.hpp"
 
@@ -43,7 +44,7 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
  * @param parameter_value String containing 'package_name/subfolder' for the directory path to look up
  * @return Full path to the directory specified by the parameter_value
  */
-std::string GetDirectoryPath(const std::string& parameter_value);
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value);
 
 /**
  * @brief Function to load BehaviorTree xml files from a specific directory
@@ -52,7 +53,7 @@ std::string GetDirectoryPath(const std::string& parameter_value);
  * @param directory_path Full path to the directory to search for BehaviorTree definitions
  */
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path);
+                       const std::filesystem::path& directory_path);
 
 /**
  * @brief Function to load a BehaviorTree ROS plugin (or standard BT.CPP plugins)

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -39,12 +39,32 @@ namespace BT
 btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status);
 
 /**
+ * @brief Resolve directory path from parameter value. Differentiates between the following formats:
+ *
+ * - `package://<package name>/<subfolder>` to search using ament_index_cpp, using GetDirectoryPathFromPackage()
+ * - `file://<absolute path>` to refer to a path in the filesystem, using GetDirectoryPathFromFilesystem(). This will
+ *   resolve `~` to the user home directory. Note that paths starting with `/` will look like `file::///some/path`.
+ *
+ * @param url String containing any of the above formats for the directory path to look up
+ * @return Full path to the directory specified by the url
+ */
+std::filesystem::path GetDirectoryPath(const std::string& url);
+
+/**
+ * @brief Function the uses ament_index_cpp to get the package path of the given string.
+ *
+ * @param package_path String containing 'package_name/subfolder' for the directory path to look up
+ * @return Full path to the directory
+ */
+std::filesystem::path GetDirectoryPathFromPackage(const std::string& package_path);
+
+/**
  * @brief Function the uses ament_index_cpp to get the package path of the parameter specified by the user
  *
  * @param parameter_value String containing 'package_name/subfolder' for the directory path to look up
  * @return Full path to the directory specified by the parameter_value
  */
-std::filesystem::path GetDirectoryPath(const std::string& parameter_value);
+std::filesystem::path GetDirectoryPathFromFilesystem(const std::filesystem::path& path);
 
 /**
  * @brief Function to load BehaviorTree xml files from a specific directory

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -53,16 +53,40 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
   return action_status;
 }
 
-std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
+std::filesystem::path GetDirectoryPath(const std::string& url)
 {
-  const std::filesystem::path search_path(parameter_value);
+  static const std::string package_prefix = "package://";
+  static const std::string file_prefix = "file://";
+
+  if(url.rfind(package_prefix, 0) == 0)
+  {
+    const auto package_path = url.substr(package_prefix.length());
+    return GetDirectoryPathFromPackage(package_path);
+  }
+  else if(url.rfind(file_prefix, 0) == 0)
+  {
+    const auto file_path = url.substr(file_prefix.length());
+    return GetDirectoryPathFromFilesystem(file_path);
+  }
+  else
+  {
+    RCLCPP_ERROR(kLogger,
+                 "Invalid URL format: '%s'. Must start with either of ['%s', '%s'].",
+                 url.c_str(), package_prefix.c_str(), file_prefix.c_str());
+    return {};
+  }
+}
+
+std::filesystem::path GetDirectoryPathFromPackage(const std::string& package_path)
+{
+  const std::filesystem::path search_path(package_path);
   const auto num_path_components = std::distance(search_path.begin(), search_path.end());
 
   if(num_path_components < 2)
   {
-    RCLCPP_ERROR(kLogger, "Invalid Parameter: %s. Missing subfolder delimiter '/'.",
-                 parameter_value.c_str());
-    return "";
+    RCLCPP_ERROR(kLogger, "Invalid package path: %s. Missing subfolder delimiter '/'.",
+                 package_path.c_str());
+    return {};
   }
 
   const auto package_name = *search_path.begin();
@@ -73,8 +97,6 @@ std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
     const auto package_share_dir =
         std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
     const auto search_directory = package_share_dir / subfolder;
-    RCLCPP_DEBUG(kLogger, "Searching for Plugins/BehaviorTrees in path: %s",
-                 search_directory.c_str());
     return search_directory;
   }
   catch(const std::exception& e)
@@ -85,9 +107,23 @@ std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
   return {};
 }
 
+std::filesystem::path GetDirectoryPathFromFilesystem(const std::filesystem::path& path)
+{
+  std::string path_str = path.string();
+  if((path_str.length() >= 2 && path_str.substr(0, 2) == "~/") || (path_str == "~"))
+  {
+    const std::string home_dir = getenv("HOME");
+    path_str.replace(0, 1, home_dir);
+    return std::filesystem::path(path_str);
+  }
+  return path;
+}
+
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
+  RCLCPP_DEBUG(kLogger, "Searching recursively for BehaviorTree XMLs in path: '%s'",
+               directory_path.c_str());
   using std::filesystem::recursive_directory_iterator;
   const auto directory_options =
       std::filesystem::directory_options::follow_directory_symlink;
@@ -165,6 +201,8 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
       continue;
     }
 
+    RCLCPP_DEBUG(kLogger, "Searching recursively for plugins in path: '%s'",
+                 plugin_directory.c_str());
     using std::filesystem::recursive_directory_iterator;
     for(const auto& entry : recursive_directory_iterator(plugin_directory))
     {

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -70,10 +70,13 @@ std::filesystem::path GetDirectoryPath(const std::string& url)
   }
   else
   {
-    RCLCPP_ERROR(kLogger,
-                 "Invalid URL format: '%s'. Must start with either of ['%s', '%s'].",
-                 url.c_str(), package_prefix.c_str(), file_prefix.c_str());
-    return {};
+    // Interpret unprefixed paths as package paths for backwards compatibility
+    RCLCPP_WARN(kLogger,
+                "Invalid URL format: '%s'. Must start with either of ['%s', '%s']. Will "
+                "interpret as a package path.",
+                url.c_str(), package_prefix.c_str(), file_prefix.c_str());
+
+    return GetDirectoryPathFromPackage(url);
   }
 }
 

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -93,6 +93,12 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
       std::filesystem::directory_options::follow_directory_symlink;
   for(const auto& entry : recursive_directory_iterator(directory_path, directory_options))
   {
+    if(entry.is_symlink() && !entry.exists())
+    {
+      RCLCPP_DEBUG(kLogger, "Skipping broken symlink: %s", entry.path().c_str());
+      continue;
+    }
+
     if(entry.path().extension() == ".xml")
     {
       try

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -200,16 +200,23 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
-
     RCLCPP_DEBUG(kLogger, "Searching recursively for plugins in path: '%s'",
                  plugin_directory.c_str());
-    using std::filesystem::recursive_directory_iterator;
-    for(const auto& entry : recursive_directory_iterator(plugin_directory))
+    try
     {
-      if(entry.path().extension() == ".so")
+      using std::filesystem::recursive_directory_iterator;
+      for(const auto& entry : recursive_directory_iterator(plugin_directory))
       {
-        LoadPlugin(factory, entry.path(), ros_params);
+        if(entry.path().extension() == ".so")
+        {
+          LoadPlugin(factory, entry.path(), ros_params);
+        }
       }
+    }
+    catch(const std::exception& e)
+    {
+      RCLCPP_ERROR(kLogger, "Failed to load plugins from '%s': %s",
+                   plugin_directory.c_str(), e.what());
     }
   }
 }
@@ -223,7 +230,15 @@ void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& f
     // skip invalid subtree directories
     if(tree_directory.empty())
       continue;
-    LoadBehaviorTrees(factory, tree_directory);
+    try
+    {
+      LoadBehaviorTrees(factory, tree_directory);
+    }
+    catch(const std::exception& e)
+    {
+      RCLCPP_ERROR(kLogger, "Failed to load BehaviorTrees from '%s': %s",
+                   tree_directory.c_str(), e.what());
+    }
   }
 }
 

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -89,7 +89,9 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
   using std::filesystem::recursive_directory_iterator;
-  for(const auto& entry : recursive_directory_iterator(directory_path))
+  const auto directory_options =
+      std::filesystem::directory_options::follow_directory_symlink;
+  for(const auto& entry : recursive_directory_iterator(directory_path, directory_options))
   {
     if(entry.path().extension() == ".xml")
     {

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -22,6 +22,12 @@ static const auto kLogger = rclcpp::get_logger("bt_action_server");
 namespace BT
 {
 
+std::filesystem::path path_from_iterators(const std::filesystem::path::iterator& first,
+                                          const std::filesystem::path::iterator& last)
+{
+  return std::accumulate(first, last, std::filesystem::path{}, std::divides{});
+}
+
 btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
 {
   btcpp_ros2_interfaces::msg::NodeStatus action_status;
@@ -47,23 +53,26 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
   return action_status;
 }
 
-std::string GetDirectoryPath(const std::string& parameter_value)
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
 {
-  std::string package_name, subfolder;
-  auto pos = parameter_value.find_first_of("/");
-  if(pos == parameter_value.size())
+  const std::filesystem::path search_path(parameter_value);
+  const auto num_path_components = std::distance(search_path.begin(), search_path.end());
+
+  if(num_path_components < 2)
   {
     RCLCPP_ERROR(kLogger, "Invalid Parameter: %s. Missing subfolder delimiter '/'.",
                  parameter_value.c_str());
     return "";
   }
 
-  package_name = std::string(parameter_value.begin(), parameter_value.begin() + pos);
-  subfolder = std::string(parameter_value.begin() + pos + 1, parameter_value.end());
+  const auto package_name = *search_path.begin();
+  const auto subfolder = path_from_iterators(++search_path.begin(), search_path.end());
+
   try
   {
-    std::string search_directory =
-        ament_index_cpp::get_package_share_directory(package_name) + "/" + subfolder;
+    const auto package_share_dir =
+        std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
+    const auto search_directory = package_share_dir / subfolder;
     RCLCPP_DEBUG(kLogger, "Searching for Plugins/BehaviorTrees in path: %s",
                  search_directory.c_str());
     return search_directory;
@@ -73,11 +82,11 @@ std::string GetDirectoryPath(const std::string& parameter_value)
     RCLCPP_ERROR(kLogger, "Failed to find package: %s \n %s", package_name.c_str(),
                  e.what());
   }
-  return "";
+  return {};
 }
 
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path)
+                       const std::filesystem::path& directory_path)
 {
   using std::filesystem::directory_iterator;
   for(const auto& entry : directory_iterator(directory_path))
@@ -147,8 +156,8 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
-    using std::filesystem::directory_iterator;
 
+    using std::filesystem::directory_iterator;
     for(const auto& entry : directory_iterator(plugin_directory))
     {
       if(entry.path().extension() == ".so")

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -88,8 +88,8 @@ std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
-  using std::filesystem::directory_iterator;
-  for(const auto& entry : directory_iterator(directory_path))
+  using std::filesystem::recursive_directory_iterator;
+  for(const auto& entry : recursive_directory_iterator(directory_path))
   {
     if(entry.path().extension() == ".xml")
     {
@@ -157,8 +157,8 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
       continue;
     }
 
-    using std::filesystem::directory_iterator;
-    for(const auto& entry : directory_iterator(plugin_directory))
+    using std::filesystem::recursive_directory_iterator;
+    for(const auto& entry : recursive_directory_iterator(plugin_directory))
     {
       if(entry.path().extension() == ".so")
       {

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -72,8 +72,8 @@ std::filesystem::path GetDirectoryPath(const std::string& url)
   {
     // Interpret unprefixed paths as package paths for backwards compatibility
     RCLCPP_WARN(kLogger,
-                "Invalid URL format: '%s'. Must start with either of ['%s', '%s']. Will "
-                "interpret as a package path.",
+                "Invalid/deprecated URL format: '%s'. Must start with either of ['%s', "
+                "'%s']. Will try to interpret as a package path.",
                 url.c_str(), package_prefix.c_str(), file_prefix.c_str());
 
     return GetDirectoryPathFromPackage(url);

--- a/btcpp_ros2_samples/config/sample_bt_executor.yaml
+++ b/btcpp_ros2_samples/config/sample_bt_executor.yaml
@@ -3,11 +3,11 @@ bt_action_server:
     action_name: "behavior_server" # Optional (defaults to `bt_action_server`)
     tick_frequency: 100 # Optional (defaults to 100 Hz)
     groot2_port: 1667 # Optional (defaults to 1667)
-    ros_plugins_timeout: 1000  # Optional (defaults 1000 ms)
+    ros_plugins_timeout: 1000 # Optional (defaults 1000 ms)
 
     plugins:
-      - behaviortree_cpp/bt_plugins
-      - btcpp_ros2_samples/bt_plugins
+      - package://behaviortree_cpp/bt_plugins
+      - package://btcpp_ros2_samples/bt_plugins
 
     behavior_trees:
-      - btcpp_ros2_samples/behavior_trees
+      - package://btcpp_ros2_samples/behavior_trees


### PR DESCRIPTION
# Overview
Modify the way paths in the BT Executor's config are interpreted (both paths where to look for plugins and where to look for tree description XMLs).
Before, each path was interpreted as `<package name>/<folder in that package's share folder>`. That is, a folder containing tree XMLs had to be in a ROS package, inside its `share` folder.

This PR adds the functionality to use URL prefixes:
- `file://<path to folder>` resolves to any path on the disk. Accepted are paths starting with `~/` to refer to the user's home folder and paths starting at root (`/`). Note that in the latter case, a URL will look like so: `file:///some/path`, i.e. requires triple-slash.
- `package://<package name>/<folder in that package's share folder>` resolves to folders in ROS packages as before.

For backwards compatibility, if neither `file://` nor `package://` were found at the beginning of the URL, the path will be interpreted as if it started with `package://`.

# Type(s) of Change
- 🚀 Feature

# Description of Changes
- Added function to resolve paths relative to home folder (`~/`)
- Added decision how to interpret paths according to URL prefix
- Added some more error/debug logs

# Testing
- Tested on my own laptop

# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No


## LDR Documentation

### LADR
**Does this change require a LADR?** No

### LDDR
**Does this change require a LDDR?** No

# Additional Context (Optional)

I started this a while ago and wanted to add the possibility for ad-hoc XML loading (i.e. passing an XML path directly to the execute-tree Action/Service instead of a target tree ID). But this is already an improvement, so I thought let's merge it, so we can start using the newer path syntax.


# PR Checklist

## Developer Submission Checklist
<!-- Please check off items you've completed before submitting. -->
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [x] Code has been reviewed and all comments have been addressed *
- [x] Testing documentation has been reviewed (or confirmed not needed)
- [x] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [x] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.






