### PR TITLE
Communicate tree execution failure when action was canceled

### DIFF
--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -225,6 +225,8 @@ void TreeExecutionServer::execute(
       {
         action_result->return_message = message;
       }
+      action_result->node_status.set__status(
+          btcpp_ros2_interfaces::msg::NodeStatus::FAILURE);
       RCLCPP_WARN(kLogger, action_result->return_message.c_str());
     };
 
@@ -232,7 +234,7 @@ void TreeExecutionServer::execute(
     {
       if(goal_handle->is_canceling())
       {
-        stop_action(status, "Action Server canceling and halting Behavior Tree");
+        stop_action(status, "Behavior tree execution aborted by client request");
         goal_handle->canceled(action_result);
         return;
       }


### PR DESCRIPTION
# Overview
Before, we had a BT execution finish with SUCCESS, when the tree execution was aborted.

This fits to expectations and also helps in the implementation of the GOM, especially abstract state transitions, which so far have been applied as if the tree finished successfully, even though execution was aborted.

# Type(s) of Change
- 🐞 Bugfix

# Description of Changes
- Changed behavior outcome to FAILURE when execution was aborted
- Changed wording of message when execution was aborted


# Testing
- Tested using GOM and mock robot (checking node status output and abstract state transitions)


# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No

## LDR Documentation

### LADR
**Does this change require a LADR?** No

### LDDR
**Does this change require a LDDR?** Yes
PR for proposal can be found here
[https://github.com/Nexxis-Technology/LDR/pull/19](https://github.com/Nexxis-Technology/LDR/pull/19)



# PR Checklist

## Developer Submission Checklist
<!-- Please check off items you've completed before submitting. -->
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [x] Code has been reviewed and all comments have been addressed *
- [x] Testing documentation has been reviewed (or confirmed not needed)
- [x] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [x] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



