### PR TITLE
Feature: Add timeout to topic subscription bt plugins

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -116,8 +116,12 @@ public:
    */
   static PortsList providedBasicPorts(PortsList addition)
   {
-    PortsList basic = { InputPort<std::string>("topic_name", "__default__placeholder__",
-                                               "Topic name") };
+    PortsList basic = {
+      InputPort<std::string>("topic_name", "__default__placeholder__", "Topic name"),
+      InputPort<uint32_t>("topic_data_timeout_msec", 0,
+                          "Watchdog timeout in ms. 0 = disabled"),
+      OutputPort<bool>("has_timed_out", "True if no message received within timeout"),
+    };
     basic.insert(addition.begin(), addition.end());
     return basic;
   }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -119,7 +119,7 @@ public:
     PortsList basic = {
       InputPort<std::string>("topic_name", "__default__placeholder__", "Topic name"),
       InputPort<uint32_t>("topic_data_timeout_msec", 0,
-                          "Watchdog timeout in ms. 0 = disabled"),
+                          "no topic data timeout in ms. 0 = disabled"),
       OutputPort<bool>("has_timed_out", "True if no message received within timeout"),
     };
     basic.insert(addition.begin(), addition.end());
@@ -161,16 +161,12 @@ public:
 
 private:
   bool createSubscriber(const std::string& topic_name);
-  std::optional<std::chrono::steady_clock::time_point> watchdog_start_;
+  std::chrono::steady_clock::time_point last_message_received_time_;
 
   bool hasTimedOut(uint32_t timeout_msec)
   {
-    if(!watchdog_start_.has_value())
-    {
-      watchdog_start_ = std::chrono::steady_clock::now();
-    }
     auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now() - *watchdog_start_)
+                          std::chrono::steady_clock::now() - last_message_received_time_)
                           .count();
     return elapsed_ms >= static_cast<int64_t>(timeout_msec);
   }
@@ -300,6 +296,7 @@ inline bool RosTopicSubNode<T>::createSubscriber(const std::string& topic_name)
       [this](const std::shared_ptr<T> msg) { last_msg_ = msg; });
 
   topic_name_ = topic_name;
+  last_message_received_time_ = std::chrono::steady_clock::now();
   return true;
 }
 
@@ -337,18 +334,12 @@ inline NodeStatus RosTopicSubNode<T>::tick()
   uint32_t timeout_msec = 0;
   getInput("topic_data_timeout_msec", timeout_msec);
 
-  if(timeout_msec > 0)
+  if(last_msg_)
   {
-    if(last_msg_)
-    {
-      watchdog_start_.reset();
-      setOutput<bool>("has_timed_out", false);
-    }
-    else
-    {
-      setOutput<bool>("has_timed_out", hasTimedOut(timeout_msec));
-    }
+    last_message_received_time_ = std::chrono::steady_clock::now();
   }
+
+  setOutput<bool>("has_timed_out", timeout_msec > 0 && hasTimedOut(timeout_msec));
 
   if(!latchLastMessage())
   {

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -161,6 +161,19 @@ public:
 
 private:
   bool createSubscriber(const std::string& topic_name);
+  std::optional<std::chrono::steady_clock::time_point> watchdog_start_;
+
+  bool hasTimedOut(uint32_t timeout_msec)
+  {
+    if(!watchdog_start_.has_value())
+    {
+      watchdog_start_ = std::chrono::steady_clock::now();
+    }
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - *watchdog_start_)
+                          .count();
+    return elapsed_ms >= static_cast<int64_t>(timeout_msec);
+  }
 };
 
 //----------------------------------------------------------------
@@ -320,6 +333,23 @@ inline NodeStatus RosTopicSubNode<T>::tick()
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus(onTick(last_msg_));
+
+  uint32_t timeout_msec = 0;
+  getInput("topic_data_timeout_msec", timeout_msec);
+
+  if(timeout_msec > 0)
+  {
+    if(last_msg_)
+    {
+      watchdog_start_.reset();
+      setOutput<bool>("has_timed_out", false);
+    }
+    else
+    {
+      setOutput<bool>("has_timed_out", hasTimedOut(timeout_msec));
+    }
+  }
+
   if(!latchLastMessage())
   {
     last_msg_.reset();


### PR DESCRIPTION
<!--
Nexxis PR Template
Use this template for all pull requests: features, bugfixes, refactors, tech debt, etc.
Please remove or skip any sections that are not relevant to your PR.
-->

# Overview
<!-- Describe the purpose of this PR. This should allow any one unfamiliar with
the work to understand the context. Aim for 2–3 sentences. Feel free to use existing
documentation or items to aid as support materials, via links, as long as the links
are long-lived. -->
This PR introduces an improvement to `RosTopicSubNode` wherein we can tell if not a single msg has been received in a given timeout period. This helps BTs that need an ongoing subscription — such as waiting for a value to fall within a range — to distinguish between a topic with no active publishers and one that is publishing but simply not meeting the required condition.

# Type(s) of Change
<!-- Uncomment the most relevant type(s) for this PR. -->
- 🚀 Feature
<!-- - 🐞 Bugfix -->
<!-- - ♻️ Refactor / Code Cleanup -->
<!-- - 📈 Tech Debt Reduction -->
<!-- - 📄 Documentation -->
<!-- - ⚙️ Infrastructure / Build System -->

# Description of Changes
<!-- Describe what was changed and why. Use bullet points if helpful. -->
- Added a `has_timed_out` output port to `RosTopicSubNode` that is set when no topic data is received within `topic_data_timeout_msec`. Only active when `topic_data_timeout_msec` is greater than 0.

# Testing
<!-- Describe what testing you have done and how someone else can reproduce it. -->
- Tested in simulation

# Documentation
## Testing Documentation
<!-- If **Yes**, please provide a link and summarize the changes. -->
**Does this change require new or updated testing documentation?** [No]  
<!-- [Testing Documentation Link]() -->

## LDR Documentation
<!-- Nexxis LDR repo (private): https://github.com/Nexxis-Technology/LDR -->

### LADR
<!-- If **Yes**, please provide a link to the decision document. -->
**Does this change require a LADR?** [No]  
<!-- [LADR Link]() -->

### LDDR
<!-- If **Yes**, please provide a link to the decision document. -->
**Does this change require a LDDR?** [No]  
<!-- [LDDR Link]() -->


# PR Checklist

## Developer Submission Checklist
<!-- Please check off items you've completed before submitting. -->
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [x] Code has been reviewed and all comments have been addressed *
- [x] Testing documentation has been reviewed (or confirmed not needed)
- [x] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [x] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



