### PR TITLE
Avoid confusing wording when BT execution aborted

### DIFF
--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -234,7 +234,7 @@ void TreeExecutionServer::execute(
     {
       if(goal_handle->is_canceling())
       {
-        stop_action(status, "Behavior tree execution aborted by client request");
+        stop_action(status, "Abort of behavior tree execution was triggered.");
         goal_handle->canceled(action_result);
         return;
       }

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -234,7 +234,7 @@ void TreeExecutionServer::execute(
     {
       if(goal_handle->is_canceling())
       {
-        stop_action(status, "Abort of behavior tree execution was triggered.");
+        stop_action(status, "Behavior tree execution aborted.");
         goal_handle->canceled(action_result);
         return;
       }


### PR DESCRIPTION
# Overview
The message that ends up in the NodeStatus when the Action Server gets the request to abort used to say
"Behavior tree execution aborted by client request"

As the messages from the NodeStatus are shown in the UI, this may be confusing to a user when the abort-request actually came from a triggered GOM fault/alert.

This PR updates the message to be more neutral to the reason for aborting the Action.

# Type(s) of Change
- 🐞 Bugfix
- ♻️ UX Improvement

# Description of Changes
- Changed wording in the message to omit the "client request"

# Testing
- Tested in simulation

# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No

## LDR Documentation

### LADR
**Does this change require a LADR?** No

### LDDR
**Does this change require a LDDR?** No


# PR Checklist

## Developer Submission Checklist
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [x] Code has been reviewed and all comments have been addressed *
- [x] Testing documentation has been reviewed (or confirmed not needed)
- [x] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [x] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



