### PR TITLE
Log non-existing search directory as warning instead of error

### DIFF
--- a/behaviortree_ros2/CMakeLists.txt
+++ b/behaviortree_ros2/CMakeLists.txt
@@ -11,6 +11,7 @@ set(THIS_PACKAGE_DEPS
     behaviortree_cpp
     btcpp_ros2_interfaces
     generate_parameter_library
+    std_srvs
     )
 
 find_package(ament_cmake REQUIRED)

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -116,8 +116,12 @@ public:
    */
   static PortsList providedBasicPorts(PortsList addition)
   {
-    PortsList basic = { InputPort<std::string>("topic_name", "__default__placeholder__",
-                                               "Topic name") };
+    PortsList basic = {
+      InputPort<std::string>("topic_name", "__default__placeholder__", "Topic name"),
+      InputPort<uint32_t>("topic_data_timeout_msec", 0,
+                          "no topic data timeout in ms. 0 = disabled"),
+      OutputPort<bool>("has_timed_out", "True if no message received within timeout"),
+    };
     basic.insert(addition.begin(), addition.end());
     return basic;
   }
@@ -157,6 +161,15 @@ public:
 
 private:
   bool createSubscriber(const std::string& topic_name);
+  std::chrono::steady_clock::time_point last_message_received_time_;
+
+  bool hasTimedOut(uint32_t timeout_msec)
+  {
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - last_message_received_time_)
+                          .count();
+    return elapsed_ms >= static_cast<int64_t>(timeout_msec);
+  }
 };
 
 //----------------------------------------------------------------
@@ -283,6 +296,7 @@ inline bool RosTopicSubNode<T>::createSubscriber(const std::string& topic_name)
       [this](const std::shared_ptr<T> msg) { last_msg_ = msg; });
 
   topic_name_ = topic_name;
+  last_message_received_time_ = std::chrono::steady_clock::now();
   return true;
 }
 
@@ -316,6 +330,17 @@ inline NodeStatus RosTopicSubNode<T>::tick()
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus(onTick(last_msg_));
+
+  uint32_t timeout_msec = 0;
+  getInput("topic_data_timeout_msec", timeout_msec);
+
+  if(last_msg_)
+  {
+    last_message_received_time_ = std::chrono::steady_clock::now();
+  }
+
+  setOutput<bool>("has_timed_out", timeout_msec > 0 && hasTimedOut(timeout_msec));
+
   if(!latchLastMessage())
   {
     last_msg_.reset();

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <thread>
+#include <filesystem>
 
 #include "btcpp_ros2_interfaces/msg/node_status.hpp"
 
@@ -43,7 +44,7 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
  * @param parameter_value String containing 'package_name/subfolder' for the directory path to look up
  * @return Full path to the directory specified by the parameter_value
  */
-std::string GetDirectoryPath(const std::string& parameter_value);
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value);
 
 /**
  * @brief Function to load BehaviorTree xml files from a specific directory
@@ -52,7 +53,7 @@ std::string GetDirectoryPath(const std::string& parameter_value);
  * @param directory_path Full path to the directory to search for BehaviorTree definitions
  */
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path);
+                       const std::filesystem::path& directory_path);
 
 /**
  * @brief Function to load a BehaviorTree ROS plugin (or standard BT.CPP plugins)

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -39,12 +39,33 @@ namespace BT
 btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status);
 
 /**
- * @brief Function the uses ament_index_cpp to get the package path of the parameter specified by the user
+ * @brief Resolve directory path from parameter value. Differentiates between the following formats:
  *
- * @param parameter_value String containing 'package_name/subfolder' for the directory path to look up
+ * - `package://<package name>/<subfolder>` to search using ament_index_cpp, using GetDirectoryPathFromPackage()
+ * - `file://<absolute path>` to refer to a path in the filesystem, using GetDirectoryPathFromFilesystem(). This will
+ *   resolve `~` to the user home directory. Note that paths starting with `/` will look like `file::///some/path`.
+ *
+ * @param url String containing any of the above formats for the directory path to look up
+ * @return Full path to the directory specified by the url
+ */
+std::filesystem::path GetDirectoryPath(const std::string& url);
+
+/**
+ * @brief Function that uses ament_index_cpp to get the package path of the given string.
+ *
+ * @param package_path String containing 'package_name/subfolder' for the directory path to look up
+ * @return Full path to the directory
+ */
+std::filesystem::path GetDirectoryPathFromPackage(const std::string& package_path);
+
+/**
+ * @brief Function that resolves filesystem paths, expanding `~` to the user home directory.
+ *
+ * @param parameter_value String containing a directory path to look up. The path may start with `~/` to refer to the user
+ * home directory.
  * @return Full path to the directory specified by the parameter_value
  */
-std::filesystem::path GetDirectoryPath(const std::string& parameter_value);
+std::filesystem::path GetDirectoryPathFromFilesystem(const std::filesystem::path& path);
 
 /**
  * @brief Function to load BehaviorTree xml files from a specific directory

--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -21,6 +21,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
+#include "std_srvs/srv/trigger.hpp"
+
 namespace BT
 {
 
@@ -35,6 +37,7 @@ class TreeExecutionServer
 public:
   using ExecuteTree = btcpp_ros2_interfaces::action::ExecuteTree;
   using GoalHandleExecuteTree = rclcpp_action::ServerGoalHandle<ExecuteTree>;
+  using Trigger = std_srvs::srv::Trigger;
 
   /**
    * @brief Constructor that will create its own instance of rclcpp::Node
@@ -187,6 +190,22 @@ private:
    * @param goal_handle Server goal handle to process feedback and set the response when finished
    */
   void execute(const std::shared_ptr<GoalHandleExecuteTree> goal_handle);
+
+  /**
+   * @brief Handle the pause service request
+   * @param request The request to pause the action server
+   * @param response The response to the pause request
+   */
+  void handle_pause(Trigger::Request::ConstSharedPtr request,
+                    Trigger::Response::SharedPtr response);
+
+  /**
+   * @brief Handle the resume service request
+   * @param request The request to resume the action server
+   * @param response The response to the resume request
+   */
+  void handle_resume(Trigger::Request::ConstSharedPtr request,
+                     Trigger::Response::SharedPtr response);
 };
 
 }  // namespace BT

--- a/behaviortree_ros2/package.xml
+++ b/behaviortree_ros2/package.xml
@@ -2,7 +2,7 @@
   <name>behaviortree_ros2</name>
   <version>0.2.0</version>
   <description>
-  This package provides a ROS2 wrapper, on top of BehaviorTree.CPP.
+    This package provides a ROS2 wrapper, on top of BehaviorTree.CPP.
   </description>
 
   <maintainer email="davide.faconti@gmail.com">Davide Faconti</maintainer>
@@ -19,9 +19,10 @@
   <depend>behaviortree_cpp</depend>
   <depend>generate_parameter_library</depend>
   <depend>btcpp_ros2_interfaces</depend>
+  <depend>std_srvs</depend>
 
-<export>
-  <build_type>ament_cmake</build_type>
-</export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -53,16 +53,43 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
   return action_status;
 }
 
-std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
+std::filesystem::path GetDirectoryPath(const std::string& url)
 {
-  const std::filesystem::path search_path(parameter_value);
+  static const std::string package_prefix = "package://";
+  static const std::string file_prefix = "file://";
+
+  if(url.rfind(package_prefix, 0) == 0)
+  {
+    const auto package_path = url.substr(package_prefix.length());
+    return GetDirectoryPathFromPackage(package_path);
+  }
+  else if(url.rfind(file_prefix, 0) == 0)
+  {
+    const auto file_path = url.substr(file_prefix.length());
+    return GetDirectoryPathFromFilesystem(file_path);
+  }
+  else
+  {
+    // Interpret unprefixed paths as package paths for backwards compatibility
+    RCLCPP_WARN(kLogger,
+                "Invalid/deprecated URL format: '%s'. Must start with either of ['%s', "
+                "'%s']. Will try to interpret as a package path.",
+                url.c_str(), package_prefix.c_str(), file_prefix.c_str());
+
+    return GetDirectoryPathFromPackage(url);
+  }
+}
+
+std::filesystem::path GetDirectoryPathFromPackage(const std::string& package_path)
+{
+  const std::filesystem::path search_path(package_path);
   const auto num_path_components = std::distance(search_path.begin(), search_path.end());
 
   if(num_path_components < 2)
   {
-    RCLCPP_ERROR(kLogger, "Invalid Parameter: %s. Missing subfolder delimiter '/'.",
-                 parameter_value.c_str());
-    return "";
+    RCLCPP_ERROR(kLogger, "Invalid package path: %s. Missing subfolder delimiter '/'.",
+                 package_path.c_str());
+    return {};
   }
 
   const auto package_name = *search_path.begin();
@@ -85,9 +112,23 @@ std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
   return {};
 }
 
+std::filesystem::path GetDirectoryPathFromFilesystem(const std::filesystem::path& path)
+{
+  std::string path_str = path.string();
+  if((path_str.length() >= 2 && path_str.substr(0, 2) == "~/") || (path_str == "~"))
+  {
+    const std::string home_dir = getenv("HOME");
+    path_str.replace(0, 1, home_dir);
+    return std::filesystem::path(path_str);
+  }
+  return path;
+}
+
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::filesystem::path& directory_path)
 {
+  RCLCPP_DEBUG(kLogger, "Searching recursively for BehaviorTree XMLs in path: '%s'",
+               directory_path.c_str());
   using std::filesystem::recursive_directory_iterator;
   const auto directory_options =
       std::filesystem::directory_options::follow_directory_symlink;
@@ -164,14 +205,23 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
-
-    using std::filesystem::recursive_directory_iterator;
-    for(const auto& entry : recursive_directory_iterator(plugin_directory))
+    RCLCPP_DEBUG(kLogger, "Searching recursively for plugins in path: '%s'",
+                 plugin_directory.c_str());
+    try
     {
-      if(entry.path().extension() == ".so")
+      using std::filesystem::recursive_directory_iterator;
+      for(const auto& entry : recursive_directory_iterator(plugin_directory))
       {
-        LoadPlugin(factory, entry.path(), ros_params);
+        if(entry.path().extension() == ".so")
+        {
+          LoadPlugin(factory, entry.path(), ros_params);
+        }
       }
+    }
+    catch(const std::exception& e)
+    {
+      RCLCPP_ERROR(kLogger, "Failed to load plugins from '%s': %s",
+                   plugin_directory.c_str(), e.what());
     }
   }
 }
@@ -185,7 +235,15 @@ void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& f
     // skip invalid subtree directories
     if(tree_directory.empty())
       continue;
-    LoadBehaviorTrees(factory, tree_directory);
+    try
+    {
+      LoadBehaviorTrees(factory, tree_directory);
+    }
+    catch(const std::exception& e)
+    {
+      RCLCPP_ERROR(kLogger, "Failed to load BehaviorTrees from '%s': %s",
+                   tree_directory.c_str(), e.what());
+    }
   }
 }
 

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -22,6 +22,12 @@ static const auto kLogger = rclcpp::get_logger("bt_action_server");
 namespace BT
 {
 
+std::filesystem::path path_from_iterators(const std::filesystem::path::iterator& first,
+                                          const std::filesystem::path::iterator& last)
+{
+  return std::accumulate(first, last, std::filesystem::path{}, std::divides{});
+}
+
 btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
 {
   btcpp_ros2_interfaces::msg::NodeStatus action_status;
@@ -47,23 +53,26 @@ btcpp_ros2_interfaces::msg::NodeStatus ConvertNodeStatus(BT::NodeStatus& status)
   return action_status;
 }
 
-std::string GetDirectoryPath(const std::string& parameter_value)
+std::filesystem::path GetDirectoryPath(const std::string& parameter_value)
 {
-  std::string package_name, subfolder;
-  auto pos = parameter_value.find_first_of("/");
-  if(pos == parameter_value.size())
+  const std::filesystem::path search_path(parameter_value);
+  const auto num_path_components = std::distance(search_path.begin(), search_path.end());
+
+  if(num_path_components < 2)
   {
     RCLCPP_ERROR(kLogger, "Invalid Parameter: %s. Missing subfolder delimiter '/'.",
                  parameter_value.c_str());
     return "";
   }
 
-  package_name = std::string(parameter_value.begin(), parameter_value.begin() + pos);
-  subfolder = std::string(parameter_value.begin() + pos + 1, parameter_value.end());
+  const auto package_name = *search_path.begin();
+  const auto subfolder = path_from_iterators(++search_path.begin(), search_path.end());
+
   try
   {
-    std::string search_directory =
-        ament_index_cpp::get_package_share_directory(package_name) + "/" + subfolder;
+    const auto package_share_dir =
+        std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
+    const auto search_directory = package_share_dir / subfolder;
     RCLCPP_DEBUG(kLogger, "Searching for Plugins/BehaviorTrees in path: %s",
                  search_directory.c_str());
     return search_directory;
@@ -73,15 +82,23 @@ std::string GetDirectoryPath(const std::string& parameter_value)
     RCLCPP_ERROR(kLogger, "Failed to find package: %s \n %s", package_name.c_str(),
                  e.what());
   }
-  return "";
+  return {};
 }
 
 void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
-                       const std::string& directory_path)
+                       const std::filesystem::path& directory_path)
 {
-  using std::filesystem::directory_iterator;
-  for(const auto& entry : directory_iterator(directory_path))
+  using std::filesystem::recursive_directory_iterator;
+  const auto directory_options =
+      std::filesystem::directory_options::follow_directory_symlink;
+  for(const auto& entry : recursive_directory_iterator(directory_path, directory_options))
   {
+    if(entry.is_symlink() && !entry.exists())
+    {
+      RCLCPP_DEBUG(kLogger, "Skipping broken symlink: %s", entry.path().c_str());
+      continue;
+    }
+
     if(entry.path().extension() == ".xml")
     {
       try
@@ -147,9 +164,9 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
-    using std::filesystem::directory_iterator;
 
-    for(const auto& entry : directory_iterator(plugin_directory))
+    using std::filesystem::recursive_directory_iterator;
+    for(const auto& entry : recursive_directory_iterator(plugin_directory))
     {
       if(entry.path().extension() == ".so")
       {

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -225,6 +225,8 @@ void TreeExecutionServer::execute(
       {
         action_result->return_message = message;
       }
+      action_result->node_status.set__status(
+          btcpp_ros2_interfaces::msg::NodeStatus::FAILURE);
       RCLCPP_WARN(kLogger, action_result->return_message.c_str());
     };
 
@@ -232,7 +234,7 @@ void TreeExecutionServer::execute(
     {
       if(goal_handle->is_canceling())
       {
-        stop_action(status, "Action Server canceling and halting Behavior Tree");
+        stop_action(status, "Behavior tree execution aborted by client request");
         goal_handle->canceled(action_result);
         return;
       }

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -234,7 +234,7 @@ void TreeExecutionServer::execute(
     {
       if(goal_handle->is_canceling())
       {
-        stop_action(status, "Behavior tree execution aborted by client request");
+        stop_action(status, "Behavior tree execution aborted.");
         goal_handle->canceled(action_result);
         return;
       }

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -40,6 +40,10 @@ struct TreeExecutionServer::Pimpl
   rclcpp_action::Server<ExecuteTree>::SharedPtr action_server;
   std::thread action_thread;
 
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr pause_service;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr resume_service;
+  bool paused = false;
+
   std::shared_ptr<bt_server::ParamListener> param_listener;
   bt_server::Params params;
 
@@ -76,6 +80,16 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::Node::SharedPtr& node)
       },
       [this](const std::shared_ptr<GoalHandleExecuteTree> goal_handle) {
         handle_accepted(std::move(goal_handle));
+      });
+
+  p_->pause_service = node_->create_service<Trigger>(
+      "pause_tree_execution",
+      [this](Trigger::Request::ConstSharedPtr request,
+             Trigger::Response::SharedPtr response) { handle_pause(request, response); });
+  p_->resume_service = node_->create_service<Trigger>(
+      "resume_tree_execution", [this](Trigger::Request::ConstSharedPtr request,
+                                      Trigger::Response::SharedPtr response) {
+        handle_resume(request, response);
       });
 
   // we use a wall timer to run asynchronously executeRegistration();
@@ -157,6 +171,7 @@ void TreeExecutionServer::handle_accepted(
   {
     p_->action_thread.join();
   }
+  p_->paused = false;
   // To avoid blocking the executor start a new thread to process the goal
   p_->action_thread = std::thread{ [=]() { execute(goal_handle); } };
 }
@@ -222,8 +237,16 @@ void TreeExecutionServer::execute(
         return;
       }
 
-      // tick the tree once and publish the action feedback
-      status = p_->tree.tickExactlyOnce();
+      // tick the tree once (if not paused) and publish the action feedback
+      if(p_->paused)
+      {
+        status = BT::NodeStatus::RUNNING;
+        RCLCPP_DEBUG(kLogger, "Action Server is paused, skipping tick.");
+      }
+      else
+      {
+        status = p_->tree.tickExactlyOnce();
+      }
 
       if(const auto res = onLoopAfterTick(status); res.has_value())
       {
@@ -232,7 +255,13 @@ void TreeExecutionServer::execute(
         return;
       }
 
-      if(const auto res = onLoopFeedback(); res.has_value())
+      if(p_->paused)
+      {
+        auto feedback = std::make_shared<ExecuteTree::Feedback>();
+        feedback->message = "Tree execution paused.";
+        goal_handle->publish_feedback(feedback);
+      }
+      else if(const auto res = onLoopFeedback(); res.has_value())
       {
         auto feedback = std::make_shared<ExecuteTree::Feedback>();
         feedback->message = res.value();
@@ -282,6 +311,20 @@ void TreeExecutionServer::execute(
     RCLCPP_ERROR(kLogger, action_result->return_message.c_str());
     goal_handle->abort(action_result);
   }
+}
+
+void TreeExecutionServer::handle_pause(Trigger::Request::ConstSharedPtr /*request*/,
+                                       Trigger::Response::SharedPtr response)
+{
+  p_->paused = true;
+  response->success = true;
+}
+
+void TreeExecutionServer::handle_resume(Trigger::Request::ConstSharedPtr /*request*/,
+                                        Trigger::Response::SharedPtr response)
+{
+  p_->paused = false;
+  response->success = true;
 }
 
 const std::string& TreeExecutionServer::treeName() const

--- a/btcpp_ros2_samples/config/sample_bt_executor.yaml
+++ b/btcpp_ros2_samples/config/sample_bt_executor.yaml
@@ -3,11 +3,11 @@ bt_action_server:
     action_name: "behavior_server" # Optional (defaults to `bt_action_server`)
     tick_frequency: 100 # Optional (defaults to 100 Hz)
     groot2_port: 1667 # Optional (defaults to 1667)
-    ros_plugins_timeout: 1000  # Optional (defaults 1000 ms)
+    ros_plugins_timeout: 1000 # Optional (defaults 1000 ms)
 
     plugins:
-      - behaviortree_cpp/bt_plugins
-      - btcpp_ros2_samples/bt_plugins
+      - package://behaviortree_cpp/bt_plugins
+      - package://btcpp_ros2_samples/bt_plugins
 
     behavior_trees:
-      - btcpp_ros2_samples/behavior_trees
+      - package://btcpp_ros2_samples/behavior_trees


### PR DESCRIPTION
# Overview
Currently, when a directory to search XMLs or BT plugins in does not exist, an error gets logged. It does not disrupt operation but is slightly misleading.
This PR reduces the log level down to a warning.

# Type(s) of Change
- 🐞 Bugfix

# Description of Changes
- Added check whether path exists to log a warning 

# Testing
- Tested on my laptop

# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No

## LDR Documentation

### LADR
**Does this change require a LADR?** No

### LDDR
**Does this change require a LDDR?** No


# PR Checklist

## Developer Submission Checklist
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [ ] Code has been reviewed and all comments have been addressed *
- [ ] Testing documentation has been reviewed (or confirmed not needed)
- [ ] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [ ] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



