### PR TITLE
Log non-existing folders as warnings, not errors

### DIFF
--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -205,6 +205,13 @@ void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory
     {
       continue;
     }
+    else if(!std::filesystem::exists(plugin_directory))
+    {
+      RCLCPP_WARN(kLogger, "The given search directory for plugins does not exist: '%s'",
+                  plugin_directory.c_str());
+      continue;
+    }
+
     RCLCPP_DEBUG(kLogger, "Searching recursively for plugins in path: '%s'",
                  plugin_directory.c_str());
     try
@@ -234,7 +241,16 @@ void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& f
     const auto tree_directory = GetDirectoryPath(tree_dir);
     // skip invalid subtree directories
     if(tree_directory.empty())
+    {
       continue;
+    }
+    else if(!std::filesystem::exists(tree_directory))
+    {
+      RCLCPP_WARN(kLogger, "The given search directory for BT XMLs does not exist: '%s'",
+                  tree_directory.c_str());
+      continue;
+    }
+
     try
     {
       LoadBehaviorTrees(factory, tree_directory);


### PR DESCRIPTION
# Overview
Currently, when a directory to search XMLs or BT plugins in does not exist, an error gets logged. It does not disrupt operation but is slightly misleading.
This PR reduces the log level down to a warning.

# Type(s) of Change
- 🐞 Bugfix

# Description of Changes
- Added check whether path exists to log a warning 

# Testing
- Tested on my laptop

# Documentation
## Testing Documentation
**Does this change require new or updated testing documentation?** No

## LDR Documentation

### LADR
**Does this change require a LADR?** No

### LDDR
**Does this change require a LDDR?** No


# PR Checklist

## Developer Submission Checklist
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [x] Code has been reviewed and all comments have been addressed *
- [x] Testing documentation has been reviewed (or confirmed not needed)
- [x] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [x] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



